### PR TITLE
[#47] | Made raw response tab scrollable

### DIFF
--- a/src/components/ResponsePanel/index.scss
+++ b/src/components/ResponsePanel/index.scss
@@ -14,6 +14,11 @@
   .raw-response {
     text-align: left;
     padding: 0 20px;
+    overflow: scroll;
+    height: 85%;
+    font-size: 14px;
+    line-height: 19px;
+    font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, "Source Code Pro", source-code-pro, monospace;
   }
 
   .response-panel-header {


### PR DESCRIPTION
Updated to make raw response tab scrollable .This is an implementation based on the issue #47 

Find the screenshot below for the fix

<img width="1278" alt="image" src="https://github.com/req-io/req.io/assets/58027046/1934b133-6859-41b0-9cdd-a02fd7c12205">


