### PR TITLE
[#91] | [Pravitha] | Removed header row from request params panel

### DIFF
--- a/src/components/RequestParamsPanel/index.tsx
+++ b/src/components/RequestParamsPanel/index.tsx
@@ -53,13 +53,6 @@ const RequestParamsPanel = (props: RequestParamPanelProps) => {
   return (
     <div className="request-params-panel">
       <table className="params-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Value</th>
-            <th>Action</th>
-          </tr>
-        </thead>
         <tbody>{paramRows}</tbody>
       </table>
       <button className="button" onClick={onNewParamAddition}>

--- a/tests/components/RequestParamsPanel.test.tsx
+++ b/tests/components/RequestParamsPanel.test.tsx
@@ -26,10 +26,6 @@ describe('RequestParamsPanel', () => {
   it('should render the given parameters with its associated delete button', () => {
     render(<RequestParamsPanel {...defaultProps} />);
 
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Value')).toBeInTheDocument();
-    expect(screen.getByText('Action')).toBeInTheDocument();
-
     expect(screen.getAllByPlaceholderText('Key')).toHaveLength(2);
     expect(screen.getAllByPlaceholderText('Value')).toHaveLength(2);
 


### PR DESCRIPTION
Removed the redundant header row from the request params panel
<img width="688" alt="Screenshot 2024-10-31 at 12 32 30 PM" src="https://github.com/user-attachments/assets/996e4106-6d7a-4062-aa43-d67f1b488567">
