### PR TITLE
[ #116 ] [ Anil ] Add support for displaying response headers

### DIFF
--- a/src/components/AppBody/index.tsx
+++ b/src/components/AppBody/index.tsx
@@ -26,6 +26,7 @@ const AppBody = () => {
   const [isNoRequestTriggered, setIsNoRequestTriggered] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [response, setResponse] = useState('');
+  const [responseHeaders, setResponseHeaders] = useState<Header[]>([]);
   const [statusCode, setStatusCode] = useState(0);
   const [statusText, setStatusText] = useState('');
   const [timeTaken, setTimeTaken] = useState(0);
@@ -37,6 +38,12 @@ const AppBody = () => {
 
     setIsLoading(false);
     setResponse(JSON.stringify(response.data, null, 2));
+    setResponseHeaders(
+      Object.entries(response.headers).map(([key, value]) => ({
+        key,
+        value: Array.isArray(value) ? value.join(', ') : value,
+      }))
+    );
     setStatusCode(response.status);
     setStatusText(response.statusText || getHttpStatusText(response.status));
   };
@@ -45,6 +52,12 @@ const AppBody = () => {
     setIsLoading(false);
     if (error.response) {
       setResponse(JSON.stringify(error.response?.data || {}, null, 2));
+      setResponseHeaders(
+        Object.entries(error.response?.headers || {}).map(([key, value]) => ({
+          key,
+          value: Array.isArray(value) ? value.join(', ') : value,
+        }))
+      );
       setStatusCode(error.response?.status || 0);
       setStatusText(error.response?.statusText || getHttpStatusText(statusCode));
     } else {
@@ -146,6 +159,7 @@ const AppBody = () => {
           isNoRequestTriggered={isNoRequestTriggered}
           isLoading={isLoading}
           response={response}
+          headers={responseHeaders}
           statusCode={statusCode}
           statusText={statusText}
           timeTaken={timeTaken}

--- a/src/components/RequestHeadersPanel/index.scss
+++ b/src/components/RequestHeadersPanel/index.scss
@@ -36,9 +36,9 @@
             Roboto Condensed,
             sans-serif;
           flex: 1;
-          height: 100%;
           width: 100%;
           font-size: 14px;
+          line-height: 20px;
           padding: 10px 0;
           outline: none;
           background-color: colors.$primary-color;

--- a/src/components/ResponseHeadersPanel/index.scss
+++ b/src/components/ResponseHeadersPanel/index.scss
@@ -1,0 +1,64 @@
+@use '../../styles/variables/colors';
+
+.response-headers-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0.2rem 1rem;
+  .headers-table {
+    border-collapse: collapse;
+    width: 45vw;
+
+    tr:nth-child(even) {
+      background-color: colors.$primary-light-color;
+      td {
+        p {
+          background-color: colors.$primary-light-color;
+        }
+      }
+    }
+
+    tr {
+      width: 100%;
+      td,
+      th {
+        border: 1px solid colors.$divider-dark-color;
+        text-align: left;
+      }
+
+      th {
+        padding: 8px;
+      }
+
+      td {
+        padding: 0 8px;
+        width: 35%;
+        p {
+          font-family:
+            Roboto Condensed,
+            sans-serif;
+          flex: 1;
+          font-size: 14px;
+          padding: 10px 0;
+          line-height: 20px;
+          margin: 0;
+          outline: none;
+          background-color: colors.$primary-color;
+          border: none;
+        }
+      }
+
+      .header-key {
+        width: 35%;
+      }
+
+      .header-value {
+        width: 65%;
+      }
+    }
+  }
+
+  .placeholder-msg {
+    color: colors.$secondary-light-color;
+  }
+}

--- a/src/components/ResponseHeadersPanel/index.tsx
+++ b/src/components/ResponseHeadersPanel/index.tsx
@@ -1,0 +1,31 @@
+import './index.scss';
+import { ResponseHeaderPanelProps } from './types.ts';
+import { Header } from '../ResponsePanel/types.ts';
+
+const ResponseHeadersPanel = (props: ResponseHeaderPanelProps) => {
+  const headerRows = props.headers.map((header: Header, index) => {
+    return (
+      <tr key={index}>
+        <td className="header-key" test-id="header-key">
+          <p>{header.key}</p>
+        </td>
+        <td className="header-value" test-id="header-value">
+          <p>{header.value}</p>
+        </td>
+      </tr>
+    );
+  });
+  return (
+    <div className="response-headers-panel">
+      {props.headers.length > 0 ? (
+        <table className="headers-table">
+          <tbody>{headerRows}</tbody>
+        </table>
+      ) : (
+        <p className="placeholder-msg">No headers to display.</p>
+      )}
+    </div>
+  );
+};
+
+export default ResponseHeadersPanel;

--- a/src/components/ResponseHeadersPanel/types.ts
+++ b/src/components/ResponseHeadersPanel/types.ts
@@ -1,0 +1,5 @@
+import { Header } from '../ResponsePanel/types';
+
+export type ResponseHeaderPanelProps = {
+  headers: Header[];
+};

--- a/src/components/ResponsePanel/index.tsx
+++ b/src/components/ResponsePanel/index.tsx
@@ -7,6 +7,7 @@ import { RawResponseViewerProps, ResponsePanelProps, StatusProps } from './types
 import { NavbarItemComponentMap } from '../Navbar/types.ts';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import SnackBar from '../Snackbar';
+import ResponseHeadersPanel from '../ResponseHeadersPanel/index.tsx';
 
 const getStatusClassName = (statusCode: number) => {
   if (statusCode >= 200 && statusCode < 300) {
@@ -46,9 +47,7 @@ function formatSize(bytes: number): string {
 }
 
 function isBlob(val: unknown): val is Blob {
-  return (
-    typeof Blob !== 'undefined' && val instanceof Blob
-    );
+  return typeof Blob !== 'undefined' && val instanceof Blob;
 }
 
 const ResponsePanel = (props: ResponsePanelProps) => {
@@ -57,6 +56,7 @@ const ResponsePanel = (props: ResponsePanelProps) => {
   const items = [
     { name: 'preview', label: 'Preview' },
     { name: 'raw', label: 'Raw' },
+    { name: 'headers', label: 'Headers' },
   ];
 
   const itemsConfig = items.map((item) => ({
@@ -68,6 +68,7 @@ const ResponsePanel = (props: ResponsePanelProps) => {
   const navbarItemComponentMap: NavbarItemComponentMap = {
     preview: <Editor readOnly={true} initialValue={props.response} />,
     raw: <RawResponseViewer response={props.response} />,
+    headers: <ResponseHeadersPanel headers={props.headers} />,
   };
 
   const copyToClipboard = () => {
@@ -105,7 +106,11 @@ const ResponsePanel = (props: ResponsePanelProps) => {
         <Navbar items={itemsConfig} />
         {isRequestCompleted && (
           <div className="response-header-right">
-            <Status statusCode={props.statusCode} statusText={props.statusText} statusTime={props.timeTaken}/>
+            <Status
+              statusCode={props.statusCode}
+              statusText={props.statusText}
+              statusTime={props.timeTaken}
+            />
             <span className="response-size" style={{ marginLeft: 12 }}>
               {formatSize(responseSize)}
             </span>

--- a/src/components/ResponsePanel/types.ts
+++ b/src/components/ResponsePanel/types.ts
@@ -1,7 +1,13 @@
+export type Header = {
+  key: string;
+  value: string;
+};
+
 export type ResponsePanelProps = {
   isNoRequestTriggered: boolean;
   isLoading: boolean;
   response: string;
+  headers: Header[];
   statusCode: number;
   statusText: string;
   timeTaken: number;

--- a/tests/components/ResponseHeadersPanel.test.tsx
+++ b/tests/components/ResponseHeadersPanel.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ResponseHeadersPanel from '../../src/components/ResponseHeadersPanel';
+import '@testing-library/jest-dom';
+
+describe('ResponseHeadersPanel', () => {
+  vi.mock('@mui/icons-material/Delete', () => ({
+    default: () => <div data-testid="delete-icon" />,
+  }));
+
+  const mockHeaders = [
+    { key: 'header1', value: 'value1' },
+    { key: 'header2', value: 'value2' },
+  ];
+
+  const defaultProps = {
+    headers: mockHeaders,
+  };
+
+  it('should render the given headers with its associated delete button', () => {
+    render(<ResponseHeadersPanel {...defaultProps} />);
+
+    expect(screen.getByText('header1')).toBeInTheDocument();
+    expect(screen.getByText('value1')).toBeInTheDocument();
+    expect(screen.getByText('header2')).toBeInTheDocument();
+    expect(screen.getByText('value2')).toBeInTheDocument();
+  });
+
+  it('should render placeholder message when there are no headers', () => {
+    render(<ResponseHeadersPanel headers={[]} />);
+
+    expect(screen.getByText('No headers to display.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
As part of this PR,
- We have added support for displaying the response headers as a new tab along with the Raw and Preview tabs in the response section. 
- Also made slight modifications to the Request headers table style to make both table standardised.
- Added tests for the new component `ResponseHeadersPanel`

Attaching the screenshot of the Response headers tab

<img width="786" height="395" alt="Screenshot 2025-10-05 at 9 49 20 PM" src="https://github.com/user-attachments/assets/3c23291c-f38f-4ea3-afd1-f1dd98d23b76" />
