### PR TITLE
[#80] | Sarath Krishnan K | Bottom part of the response body not visible in preview for larger responses

### DIFF
--- a/src/components/ResponsePanel/index.scss
+++ b/src/components/ResponsePanel/index.scss
@@ -2,6 +2,9 @@
 
 .response-panel {
   width: 50%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 
   .empty-placeholder {
     display: flex;
@@ -14,9 +17,10 @@
   .raw-response {
     text-align: left;
     padding: 0 20px;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: auto;
-    height: 85%;
+    flex: 1 1 0;
+    min-height: 0;
     font-size: 14px;
     line-height: 19px;
     font-family: Monaco, Menlo, 'Ubuntu Mono', Consolas, 'Source Code Pro', source-code-pro,
@@ -44,6 +48,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    flex-shrink: 0;
 
     .navbar {
       width: 70%;


### PR DESCRIPTION
Bottom part of the response body is visible in preview for larger responses. Thus bug is fixed as expected