### PR TITLE
[#149] [sujoy] | excluded all the types.ts file from test coverage

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -62,6 +62,9 @@ export default defineConfig({
         'src/**/*.jpeg',
         'src/**/*.gif',
         'src/**/*.ico',
+
+        // types files
+        'src/**/types.ts'
       ],
       all: true,
       thresholds: {


### PR DESCRIPTION
Excluded all the types definition files from test coverage using vitest.config.ts