### PR TITLE
fixed persistent focus issue in parameters after deleting

### DIFF
--- a/src/components/RequestParamsPanel/index.tsx
+++ b/src/components/RequestParamsPanel/index.tsx
@@ -18,11 +18,6 @@ const RequestParamsPanel = (props: RequestParamPanelProps) => {
   const onParamDelete = (index: number) => {
     const updatedParams = props.params.filter((_, paramIndex) => paramIndex !== index);
     props.onParamsChange(updatedParams);
-
-    // Clear focus to prevent focus persistence on delete buttons
-    if (document.activeElement && document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
-    }
   };
 
   const paramRows = props.params.map((param: QueryParam, index) => {


### PR DESCRIPTION
This PR fixes an issue where the focus remained on the delete button even after a parameter was removed. The focus is now correctly reset, improving accessibility and preventing unintended actions during subsequent interactions.