### PR TITLE
[#175] | Krishna | Configure automated dependabot for weekly dependency scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    ignore:
+      - update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
This PR configures dependabot to automatically check for and create pull requests for outdated dependencies once per week. This helps keep dependencies up to date, ensures security patches are applied regularly, and maintains the overall health of the project.

With this change:

- [x] Automatically check for new versions of dependencies once every week
- [x] Create PRs for minor and patch upgrades of any outdated packages
- [x] Labels the dependabot PRs with `dependencies` label
- [x] Runs without impacting existing CI workflows