### PR TITLE
[#185] | Dhanoj | Removed large gap in Nav bar items when header count badge is enabled

### DIFF
--- a/src/components/Navbar/index.scss
+++ b/src/components/Navbar/index.scss
@@ -41,7 +41,6 @@
       font-size: 0.7rem;
       font-weight: normal;
       margin-left: 0.4rem;
-      margin-bottom: 1rem;
       min-width: 1.2rem;
       text-align: center;
       line-height: 1.2;


### PR DESCRIPTION
<img width="713" height="417" alt="Screenshot 2025-10-27 at 11 39 18 AM" src="https://github.com/user-attachments/assets/24689e12-e6cb-4c62-8570-b361ed1274c4" />
