### PR TITLE
[#180] | Krishna | Add explicit GITHUB_TOKEN permissions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     uses: ./.github/workflows/lint-job.yml

--- a/.github/workflows/lint-job.yml
+++ b/.github/workflows/lint-job.yml
@@ -3,6 +3,9 @@ name: Lint Job
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     uses: ./.github/workflows/lint-job.yml

--- a/.github/workflows/test-job.yml
+++ b/.github/workflows/test-job.yml
@@ -3,6 +3,9 @@ name: Test Job
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/trivy-scan-job.yml
+++ b/.github/workflows/trivy-scan-job.yml
@@ -3,6 +3,9 @@ name: Trivy Scan Job
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   trivy-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/typecheck-job.yml
+++ b/.github/workflows/typecheck-job.yml
@@ -3,6 +3,9 @@ name: Typecheck Job
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR explicitly define minimal permissions for the GITHUB_TOKEN to adhere to the principle of least privilege and eliminate the code scanning alerts by CodeQL.

Affected Files

- [x] .github/workflows/pr.yaml
- [x] .github/workflows/ci.yaml
- [x] .github/workflows/test-job.yaml
- [x] .github/workflows/typecheck-job.yaml
- [x] .github/workflows/lint-job.yaml
- [x] .github/workflows/trivy-scan-job.yml

All permission related CodeQL alerts for actions/missing-workflow-permissions should be resolved by this PR.