### PR TITLE
[#115] | Jayabharathi | Show Navbar only when there is a response

### DIFF
--- a/src/components/ResponsePanel/index.tsx
+++ b/src/components/ResponsePanel/index.tsx
@@ -116,7 +116,7 @@ const ResponsePanel = (props: ResponsePanelProps) => {
   return (
     <div className="response-panel" data-testid={'response-panel'}>
       <div className="response-panel-header">
-        <Navbar items={itemsConfig} />
+        {isRequestCompleted && <Navbar items={itemsConfig} />}
         {isRequestCompleted && (
           <div className="response-header-right">
             <Status

--- a/tests/components/ResponsePanel.test.tsx
+++ b/tests/components/ResponsePanel.test.tsx
@@ -61,7 +61,7 @@ describe(`ResponsePanel`, () => {
 
   describe(`Default Rendering components`, () => {
     it(
-      'should render Navbar and EmptyPlaceholder when and isLoading is false and isNoRequestTriggered is true',
+      'should render EmptyPlaceholder and not Navbar when isLoading is false and isNoRequestTriggered is true',
       () => {
         const props = {
           isLoading: false,
@@ -72,12 +72,12 @@ describe(`ResponsePanel`, () => {
         const navbar = screen.queryByTestId('navbar');
         const emptyPlaceholder = screen.queryByTestId('empty-placeholder');
 
-        expect(navbar).toBeInTheDocument();
+        expect(navbar).not.toBeInTheDocument();
         expect(emptyPlaceholder).toBeInTheDocument();
       }
     );
 
-    it(`should render Navbar and Spinner when isLoading is true`, () => {
+    it(`should render Spinner and not Navbar when isLoading is true`, () => {
       const props = {
         isLoading: true,
       };
@@ -86,7 +86,7 @@ describe(`ResponsePanel`, () => {
       const spinner = screen.queryByTestId('spinner');
       const navbar = screen.queryByTestId('navbar');
 
-      expect(navbar).toBeInTheDocument();
+      expect(navbar).not.toBeInTheDocument();
       expect(spinner).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Made changes to show Navbar only when there is a response as part of this issue [#115](https://github.com/req-io/req.io/issues/115)

- [x] Given the user opens the application without sending any requests
        Then the Response section Navbar should not be visible

- [x] Given the user executes a request
        When the application receives a response
        Then the Response section Navbar should appear above the response content area

- [x] Given the user sees the Response section Navbar
        When the user clicks on one of the tabs (Raw, Preview, Headers, etc.)
        Then the corresponding response view should be displayed correctly

 ## Screenshots

Before:

<img width="1452" height="902" alt="Before" src="https://github.com/user-attachments/assets/2ed1c4f1-9543-4612-9413-ca07fdb39639" />

After:

<img width="1447" height="897" alt="After" src="https://github.com/user-attachments/assets/ffbd1b1c-63c4-45a9-bc25-551326042428" />


Closes : [#115](https://github.com/req-io/req.io/issues/115)